### PR TITLE
fix github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots verify
-      - run: mkdir staging && cp drools-yaml-rules-durable/target/*-runner.jar staging
+      - run: mkdir staging && cp drools-yaml-rules-durable-rest/target/*-runner.jar staging
       - uses: actions/upload-artifact@v3
         with:
           name: Package


### PR DESCRIPTION
The last refactoring changed the path of the uberjar, this should fix it. Not necessary if #5 is merged first
