### PR TITLE
Add JPY "official" public API

### DIFF
--- a/drools-yaml-rules-durable/src/main/java/org/drools/yaml/durable/jpy/JpyDurableRulesEngine.java
+++ b/drools-yaml-rules-durable/src/main/java/org/drools/yaml/durable/jpy/JpyDurableRulesEngine.java
@@ -1,0 +1,72 @@
+package org.drools.yaml.durable.jpy;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.drools.yaml.core.RulesExecutor;
+import org.drools.yaml.core.RulesExecutorContainer;
+import org.drools.yaml.durable.DurableNotation;
+import org.drools.yaml.durable.domain.DurableRuleMatch;
+import org.kie.api.runtime.rule.Match;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.drools.yaml.core.RulesExecutor.OBJECT_MAPPER;
+
+public class JpyDurableRulesEngine {
+
+    private Iterator<Map<String, Map>> lastResponse = Collections.emptyIterator();
+
+    public long createRuleset(String ruleSetName, String rulesetString) {
+        RulesExecutor executor = RulesExecutor.createFromJson(
+                DurableNotation.INSTANCE,
+                String.format("{\"%s\":%s}", ruleSetName, rulesetString));
+        return executor.getId();
+    }
+
+    /**
+     * @return error code (currently always 0)
+     */
+    public int retractFact(long sessionId, String serializedFact) {
+        RulesExecutorContainer.INSTANCE.get(sessionId).retract(serializedFact);
+        return 0;
+    }
+
+    public String advanceState() {
+        if (lastResponse.hasNext()) {
+            Map<String, Map> elem = lastResponse.next();
+            try {
+                return OBJECT_MAPPER.writeValueAsString(elem);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            return null;
+        }
+    }
+
+    public int assertFact(long sessionId, String serializedFact) {
+        return processMessage(
+                serializedFact,
+                RulesExecutorContainer.INSTANCE.get(sessionId)::processFacts);
+    }
+
+    public int assertEvent(long sessionId, String serializedFact) {
+        return processMessage(
+                serializedFact,
+                RulesExecutorContainer.INSTANCE.get(sessionId)::processEvents);
+    }
+
+    public String getFacts(long session_id) {
+        return RulesExecutorContainer.INSTANCE.get(session_id).getAllFactsAsJson();
+    }
+
+    private int processMessage(String serializedFact, Function<String, Collection<Match>> command) {
+        List<Map<String, Map>> lastResponse = DurableRuleMatch.asList(command.apply(serializedFact));
+        this.lastResponse = lastResponse.iterator();
+        return 0;
+    }
+}

--- a/drools-yaml-rules-durable/src/test/java/org/drools/yaml/durable/jpy/JpyDurableRulesEngineTest.java
+++ b/drools-yaml-rules-durable/src/test/java/org/drools/yaml/durable/jpy/JpyDurableRulesEngineTest.java
@@ -1,0 +1,26 @@
+package org.drools.yaml.durable.jpy;
+
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JpyDurableRulesEngineTest {
+    @Test
+    public void testJpyApi() {
+
+        String name = "Test rules multiple hosts";
+        String rules = "{\"r_0\": {\"all\": [{\"m\": {\"i\": 1}}]}, \"r_1\": {\"all\": [{\"m\": {\"i\": 2}}]}, " +
+                "\"r_2\": {\"all\": [{\"m\": {\"i\": 3}}]}, " +
+                "\"r_3\": {\"all\": [{\"m\": {\"i\": 4}}]}, \"r_4\": {\"all\": [{\"m\": {\"$ex\": {\"j\": 1}}}]}}";
+
+        JpyDurableRulesEngine engine = new JpyDurableRulesEngine();
+        long id = engine.createRuleset(name, rules);
+
+        int result = engine.assertFact(id, "{\"i\": 1}");
+
+        String nextResult = engine.advanceState();
+
+        assertNotNull(nextResult);
+
+    }
+}


### PR DESCRIPTION
Create a public API for JPY consumption, instead of relying on internal implementation details. To be used via https://github.com/evacchi/ansible-events/commit/5e5d8b743278c3ecfd62c103910039c1c4058f02